### PR TITLE
Fixed bug in list.js

### DIFF
--- a/src/cli/commands/list.js
+++ b/src/cli/commands/list.js
@@ -152,7 +152,7 @@ export function setFlags(commander: Object) {
 }
 
 export function getReqDepth(inputDepth: string) : number {
-  return inputDepth && /^\d+$/.test(inputDepth) ?  Number(inputDepth) : 0;
+  return inputDepth && /^\d+$/.test(inputDepth) ?  Number(inputDepth) : -1;
 }
 
 export function filterTree(tree: Tree, filters: Array<string>): boolean {


### PR DESCRIPTION
**Summary**

-Test was throwing error of "getReqDepth should return -1 if invalid" because getReqDepth function was return 0 when invalid.
-Changed getReqDepth function to return -1 so that list.js would pass the test.


